### PR TITLE
[java-restify-netflix-eureka] Suporte para frameworks Netflix - Eureka

### DIFF
--- a/java-restify-netflix-eureka-spring-autoconfigure-sample/pom.xml
+++ b/java-restify-netflix-eureka-spring-autoconfigure-sample/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.ljtfreitas</groupId>
+	<artifactId>java-restify-netflix-eureka-spring-autoconfigure-sample</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>java-restify-netflix-spring-starter</artifactId>
+			<version>1.1.2-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-eureka-server</artifactId>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-netflix</artifactId>
+				<version>1.2.3.RELEASE</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<type>pom</type>
+				<version>1.4.3.RELEASE</version>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<debug>true</debug>
+					<compilerArgument>-parameters</compilerArgument>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/RunController.java
+++ b/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/RunController.java
@@ -1,0 +1,19 @@
+package com.github.ljtfreitas.restify.spring.netflix.sample.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/run")
+public class RunController {
+
+	@Autowired
+	private SampleApi sampleApi;
+
+	@GetMapping
+	public String run() {
+		return sampleApi.get();
+	}
+}

--- a/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/SampleApi.java
+++ b/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/SampleApi.java
@@ -1,0 +1,13 @@
+package com.github.ljtfreitas.restify.spring.netflix.sample.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.github.ljtfreitas.restify.spring.configure.Restifyable;
+
+@Restifyable(name = "sample-eureka-api", endpoint = "http://sample-eureka-api")
+public interface SampleApi {
+
+	@GetMapping("/api/sample")
+	public String get();
+
+}

--- a/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/SampleApplication.java
+++ b/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/SampleApplication.java
@@ -1,0 +1,17 @@
+package com.github.ljtfreitas.restify.spring.netflix.sample.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+@EnableEurekaClient
+public class SampleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleApplication.class);
+	}
+
+}

--- a/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/SampleController.java
+++ b/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/java/com/github/ljtfreitas/restify/spring/netflix/sample/api/SampleController.java
@@ -1,0 +1,15 @@
+package com.github.ljtfreitas.restify.spring.netflix.sample.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class SampleController {
+
+	@GetMapping("/sample")
+	public String get() {
+		return "Hello, Restify!";
+	}
+}

--- a/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/resources/application.properties
+++ b/java-restify-netflix-eureka-spring-autoconfigure-sample/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.application.name=sample-eureka-api
+
+server.port: 8761
+
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
+


### PR DESCRIPTION
## Suporte para frameworks Netflix  - Eureka (autoconfiguração para Spring Boot) :leaves: 

- Implementa exemplo utilizando o Eureka como service discovery (com a autoconfiguração do Spring NetFlix); a integração com o restify é transparente em função do uso do Ribbon :metal:.